### PR TITLE
UHN AD FS Fixes

### DIFF
--- a/src/main/java/org/apache/sling/auth/saml2/impl/AuthenticationHandlerSAML2Impl.java
+++ b/src/main/java/org/apache/sling/auth/saml2/impl/AuthenticationHandlerSAML2Impl.java
@@ -50,6 +50,7 @@ import org.opensaml.saml.saml2.binding.decoding.impl.HTTPPostDecoder;
 import org.opensaml.saml.saml2.binding.encoding.impl.HTTPRedirectDeflateEncoder;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeValue;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Issuer;
@@ -407,7 +408,7 @@ public class AuthenticationHandlerSAML2Impl extends AbstractSamlHandler implemen
     NameIDPolicy buildNameIdPolicy() {
         NameIDPolicy nameIDPolicy = Helpers.buildSAMLObject(NameIDPolicy.class);
         nameIDPolicy.setAllowCreate(true);
-        nameIDPolicy.setFormat(NameIDType.TRANSIENT);
+        nameIDPolicy.setFormat(NameIDType.UNSPECIFIED);
         return nameIDPolicy;
     }
 
@@ -505,9 +506,17 @@ public class AuthenticationHandlerSAML2Impl extends AbstractSamlHandler implemen
     private void setUserId(Attribute attribute, Saml2User saml2User) {
         logger.debug("username attr name: {}", attribute.getName());
         for (XMLObject attributeValue : attribute.getAttributeValues()) {
-            if ( ((XSString) attributeValue).getValue() != null ) {
-                saml2User.setId( ((XSString) attributeValue).getValue());
-                logger.debug("username value: {}", saml2User.getId());
+            if (attributeValue instanceof AttributeValue) {
+                if ( ((AttributeValue) attributeValue).getTextContent() != null ) {
+                    saml2User.setId( ((AttributeValue) attributeValue).getValue());
+                    logger.debug("username value: {}", saml2User.getId());
+                }
+            }
+            if (attributeValue instanceof XSString) {
+                if ( ((XSString) attributeValue).getValue() != null ) {
+                    saml2User.setId( ((XSString) attributeValue).getValue());
+                    logger.debug("username value: {}", saml2User.getId());
+                }
             }
         }
     }

--- a/src/main/java/org/apache/sling/auth/saml2/impl/AuthenticationHandlerSAML2Impl.java
+++ b/src/main/java/org/apache/sling/auth/saml2/impl/AuthenticationHandlerSAML2Impl.java
@@ -508,7 +508,7 @@ public class AuthenticationHandlerSAML2Impl extends AbstractSamlHandler implemen
         for (XMLObject attributeValue : attribute.getAttributeValues()) {
             if (attributeValue instanceof AttributeValue) {
                 if ( ((AttributeValue) attributeValue).getTextContent() != null ) {
-                    saml2User.setId( ((AttributeValue) attributeValue).getValue());
+                    saml2User.setId( ((AttributeValue) attributeValue).getTextContent());
                     logger.debug("username value: {}", saml2User.getId());
                 }
             }

--- a/src/test/java/org/apache/sling/auth/saml2/impl/OsgiSamlTest.java
+++ b/src/test/java/org/apache/sling/auth/saml2/impl/OsgiSamlTest.java
@@ -228,7 +228,7 @@ public class OsgiSamlTest {
     public void test_buildNameIdPolicy(){
         NameIDPolicy nameIDPolicy = samlHandler.buildNameIdPolicy();
         assertTrue(nameIDPolicy.getAllowCreate());
-        assertEquals("urn:oasis:names:tc:SAML:2.0:nameid-format:transient", nameIDPolicy.getFormat());
+        assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", nameIDPolicy.getFormat());
     }
 
     @Test


### PR DESCRIPTION
Fixes present in the `0.2.6.cards.1` release that are needed to make `org.apache.sling.auth.saml2` work with UHN's AD FS federated authentication servers.